### PR TITLE
If a script cannot be found, don't try to run it.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/script/GhidraScriptComponentProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/script/GhidraScriptComponentProvider.java
@@ -608,7 +608,9 @@ public class GhidraScriptComponentProvider extends ComponentProviderAdapter {
 	void runScript(ResourceFile scriptFile, TaskListener listener) {
 		lastRunScript = scriptFile;
 		GhidraScript script = doGetScriptInstance(scriptFile);
-		doRunScript(script, listener);
+		if (script != null) {
+			doRunScript(script, listener);
+		}
 	}
 
 	private GhidraScript doGetScriptInstance(ResourceFile scriptFile) {


### PR DESCRIPTION
In GhidraScriptComponentProvider.runScript(), if doGetScriptInstance() fails, it writes a diagnostic to the console and returns null.  Proceeding to call doRunScript() with this null will result in a null pointer reference, so if doGetScriptInstance() returns null, just cut things off there.